### PR TITLE
fix/remove-secret-word-display

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,6 @@ function App() {
   return (
     <div data-test="component-app" className="container">
       <h1>Jotto</h1>
-      <p>the secret word is {state.secretWord}</p>
       <languageContext.Provider value={state.language}>
         <LanguagePicker setLanguage={setLanguage} />
         <guessedWordsContext.GuessedWordsProvider>


### PR DESCRIPTION
Removed the secret word from always displaying now that we are finished testing the app. By making this change the user can now actually enjoy playing the game (because it isn't overtly obvious what the secret word is).